### PR TITLE
Add some assertions that are helpful for trouble shooting.

### DIFF
--- a/rid/entrypoint/submit.py
+++ b/rid/entrypoint/submit.py
@@ -2,7 +2,7 @@ from distutils.command.config import dump_file
 import json
 from pathlib import Path
 from typing import List, Union, Optional
-from rid.utils import load_json
+from rid.utils import load_json, check_cv_file
 import os
 
 from dflow import (
@@ -224,6 +224,8 @@ def submit_rid(
     if len(cvfile_list) == 0:
         cv_file_artifact = None
     else:
+        Rsl, Rmsg = check_cv_file(cvfile_list)
+        assert Rsl, f"An error occurred while parsing cv_files:\n\n{Rmsg}"
         cv_file_artifact = upload_artifact([Path(p) for p in cvfile_list], archive=None)
         
     if len(dpfile_list) == 0:

--- a/rid/op/label_stats.py
+++ b/rid/op/label_stats.py
@@ -91,6 +91,8 @@ class LabelStats(OP):
                     higher_index.add(i)
         higher_index_list = list(higher_index)
         print("higher index list", list(cv_forces_list[higher_index_list]))
+        assert len(higher_index_list) < len(mf_all_std_list), \
+            f"All the std are higher than the std_threshold ({op_in["std_threshold"]}), please lower the std_threshold."
         mf_all_std_list_modified = np.delete(mf_all_std_list, higher_index_list, axis=0)
         cv_forces_list_modified = np.delete(cv_forces_list, higher_index_list, axis=0)
         assert len(mf_all_std_list_modified) == len(cv_forces_list_modified)

--- a/rid/op/run_select.py
+++ b/rid/op/run_select.py
@@ -110,6 +110,10 @@ class RunSelect(OP):
             else:
                 stds = make_std(cls_sel_data, models=op_in["models"])
                 save_txt("cls_"+model_devi_name, stds, fmt=model_devi_precision)
+                assert max(stds) > trust_lvl_1, f"""
+                The maximum deviation of the models ({max(stds)}) is smaller than trust_lvl_1
+                ({trust_lvl_1}), causing the selected indices to be empty. Please enlarge trust_lvl_1.
+                """
                 _selected_idx = select_from_devi(stds, op_in["trust_lvl_1"])
             sel_idx = cls_sel_idx[_selected_idx]
             np.save(sel_ndx_name, sel_idx)

--- a/rid/utils/__init__.py
+++ b/rid/utils/__init__.py
@@ -13,3 +13,4 @@ from rid.utils.format import list_to_string
 from rid.utils.command import run_command
 from rid.utils.path import set_directory
 from rid.utils.set_config import init_executor, normalize_resources
+from rid.utils.check import check_cv_file

--- a/rid/utils/check.py
+++ b/rid/utils/check.py
@@ -1,0 +1,58 @@
+# Trouble shooting for common errors during the workflow
+
+import os
+import subprocess
+import numpy as np
+from pathlib import Path
+
+def check_cv_file(file_list : list):
+    """Parse the cv files with plumed to check if the files are valid.
+    
+    Parameters
+    ----------
+    file_list : list
+        List of file absolute paths. Only one .pdb file is allowed.
+        
+    Returns
+    -------
+    Rsl : bool
+        True if the file is valid, False otherwise.
+    Rmsg : str
+        The whole parsing message of PLUMED if the file is invalid, 
+        none otherwise.
+    """
+    input_dir = Path(file_list[0]).parent
+    os.chdir(input_dir)
+    
+    cv_file_list = [file for file in file_list if file[-4:] != ".pdb"]
+    strut_pdb = [file for file in file_list if file[-4:] == ".pdb"]
+    assert len(strut_pdb) == 1, \
+        "There should be only one .pdb file in the cv files."
+    
+    # Fetch the number of atoms from the .pdb file
+    with open(strut_pdb[0], "rb") as f:
+        block = -1024
+        flag = True
+        while flag:
+            f.seek(block, 2)
+            lines = f.readlines()
+            lines.reverse()
+            for line in lines:
+                if line.startswith(b'ATOM'):
+                    natoms = int(line[6:11])
+                    flag = False
+                    break
+            block *= 2
+    
+    # Parse the file with plumed
+    Rsl = True
+    Rmsg = ''
+    for file in cv_file_list:
+        cmd = f"plumed driver --plumed {file} \
+            --parse-only --natoms {natoms}"
+        (Status, Rmsg) = subprocess.getstatusoutput(cmd)
+        if Status != 0:
+            Rsl = False
+            break
+        
+    return Rsl, Rmsg


### PR DESCRIPTION
## 1. Checking input CV files
If there got a problem in the input CV files, these commits allow rid-kit to transmit the raw error messages produced by PLUMED to users for debug. 
Rid-kit provides little corresponding information in the workflow log file and only records a "CUDA error #1" in the gmx log. The check.py called by the newly added assertion parses the CV files with PLUMED in advance to ensure their validity and facilitating trouble-shooting.

## 2. Assertions about trust_lvl_1 and std_threshold
Too large trust_lvl_1 and too small std_threshold may emit all the data points from the training set and interrupt the workflow. When this happens, these assertions allow rid-kit to inform users to adjust the parameters.